### PR TITLE
PP-4891: Upgrade to Alpine 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM govukpay/alpine:latest-master
+FROM govukpay/alpine:3.9
 
 USER root
 
-RUN apk add --no-cache squid=3.5.27-r0
+RUN apk add --no-cache squid=4.4-r1
 RUN echo '' > /etc/squid/squid.conf
 
 RUN mkdir /squid && chown -R user /squid && chown -R user /etc/squid/squid.conf
@@ -11,4 +11,4 @@ EXPOSE 8080
 
 USER user
 
-ENTRYPOINT ash -c 'echo "$SQUID_CONFIG" | base64 -d > /etc/squid/squid.conf && squid -z && squid -N'
+ENTRYPOINT ash -c 'echo "$SQUID_CONFIG" | base64 -d > /etc/squid/squid.conf && squid -N'


### PR DESCRIPTION
This also brings in a newer version of Squid.

The container is now 17MB instead of 28MB