### PR TITLE
RED-46: Use alpine directly rather than Pay's base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-# govukpay/alpine:3.9
-FROM govukpay/alpine@sha256:7c98b51d3496a69d6f367a5c707287d49a202e304f964e17bd75eaacc960c7dc
+# alpine:3.9
+FROM alpine@sha256:769fddc7cc2f0a1c35abb2f91432e8beecf83916c421420e6a6da9f8975464b6
+
+RUN addgroup -g 1000 user && \
+    adduser  -u 1000 -G user -D user
 
 USER root
 
-RUN apk add --no-cache squid=4.4-r1
+RUN ["apk", "add", "--no-cache", "squid=4.4-r1"]
 RUN echo '' > /etc/squid/squid.conf
 
 RUN mkdir /squid && chown -R user /squid && chown -R user /etc/squid/squid.conf


### PR DESCRIPTION
We don't need to use the govukpay/alpine base image - we can just pull directly
from alpine