### PR TITLE
REP-139: Upgrade to Alpine 3.10.1, Squid 4.8 exec via Tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN addgroup -g 1000 user && \
 
 USER root
 
-RUN ["apk", "add", "--no-cache", "squid=4.8-r0"]
+RUN ["apk", "add", "--no-cache", "squid=4.8-r0", "tini"]
 RUN echo '' > /etc/squid/squid.conf
 
 RUN mkdir /squid && chown -R user /squid && chown -R user /etc/squid/squid.conf
@@ -14,4 +14,4 @@ EXPOSE 8080
 
 USER user
 
-ENTRYPOINT ash -c 'echo "$SQUID_CONFIG" | base64 -d > /etc/squid/squid.conf && squid -N'
+ENTRYPOINT tini -- ash -c 'echo "$SQUID_CONFIG" | base64 -d > /etc/squid/squid.conf && exec squid -N'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-# alpine:3.9
-FROM alpine@sha256:769fddc7cc2f0a1c35abb2f91432e8beecf83916c421420e6a6da9f8975464b6
+FROM alpine@sha256:6a92cd1fcdc8d8cdec60f33dda4db2cb1fcdcacf3410a8e05b3741f44a9b5998
 
 RUN addgroup -g 1000 user && \
     adduser  -u 1000 -G user -D user
 
 USER root
 
-RUN ["apk", "add", "--no-cache", "squid=4.4-r1"]
+RUN ["apk", "add", "--no-cache", "squid=4.8-r0"]
 RUN echo '' > /etc/squid/squid.conf
 
 RUN mkdir /squid && chown -R user /squid && chown -R user /etc/squid/squid.conf


### PR DESCRIPTION
### WHAT
Upgrades Alpine to 3.10.1 from 3.9
Upgrades Squid to 4.8
Runs Squid via Tini to correctly handle process signals and reap child processes.

### HOW
Deploy to test & staging environments. Ensure smoke tests pass.