### PR TITLE
BAU: Bump squid package version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN addgroup -g 1000 user && \
 
 USER root
 
-RUN ["apk", "add", "--no-cache", "squid=4.8-r0", "tini"]
+RUN ["apk", "add", "--no-cache", "squid=4.8-r1", "tini"]
 RUN echo '' > /etc/squid/squid.conf
 
 RUN mkdir /squid && chown -R user /squid && chown -R user /etc/squid/squid.conf


### PR DESCRIPTION
Docker container failed to build as previous revision is no longer available.