### PR TITLE
PP-6824: Bumping version of Squid Proxy to latest.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN addgroup -g 1000 user && \
 
 USER root
 
-RUN ["apk", "add", "--no-cache", "squid=4.11-r0", "tini"]
+RUN ["apk", "add", "--no-cache", "squid=4.12-r0", "tini"]
 RUN echo '' > /etc/squid/squid.conf
 
 RUN mkdir /squid && chown -R user /squid && chown -R user /etc/squid/squid.conf


### PR DESCRIPTION
# What is this?
This upgrades Squid Proxy to 4.12

That's about it, really. It doesn't do anything else.

# How?
Once merged, deploy changes to test environment, test it, then if it all looks good, start rolling it out.

# Why?
Bumping the version to 4.12 addresses a CVE related to Cache Poisoning:  
[SQUID-2020:7 Cache Poisoning Issue in HTTP Request processing](https://github.com/squid-cache/squid/security/advisories/GHSA-qf3v-rc95-96j5)