### PR TITLE
PP-6824: Enable Alpine Edge to use newer version of Squid.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN addgroup -g 1000 user && \
 
 USER root
 
-RUN ["apk", "add", "--no-cache", "squid=4.12-r0", "tini"]
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+RUN ["apk", "add", "--no-cache", "squid@edge", "tini"]
 RUN echo '' > /etc/squid/squid.conf
 
 RUN mkdir /squid && chown -R user /squid && chown -R user /etc/squid/squid.conf


### PR DESCRIPTION
## What is this?
This will address Squid not being updated to the newer version that fixes the Cache Poisoning issues. The stable repo only had Squid 4.11 whilst we require 4.12 or newer to address this.

## Why?
We previously merged a change to pin Squid to 4.12, however, we later discovered that the stable repo for our current version of Alpine only had Squid 4.11. We've agreed that the risk of using the edge repository is minimal, as any withdrawal of packages or release of any breaking changes should be caught in our smoke tests.