### PR TITLE
[PP-7478] Pin Squid to 4.13 - v5 may have breaking changes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN addgroup -g 1000 user && \
 
 USER root
 
-RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-RUN ["apk", "add", "--no-cache", "squid@edge", "tini"]
+RUN ["apk", "add", "--no-cache", "squid=4.13-r0", "tini"]
 RUN echo '' > /etc/squid/squid.conf
 
 RUN mkdir /squid && chown -R user /squid && chown -R user /etc/squid/squid.conf


### PR DESCRIPTION
## What?
This pins Squid to 4.13, the version we were originally using in Alpine Edge. As Edge has changed to 5.0.3, we'd rather pin it to 4.13-r0 on stable until such a time where we want to upgrade to Squid v5.