### PR TITLE
PP-8038: Bump Squid to v4.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN addgroup -g 1000 user && \
 
 USER root
 
-RUN ["apk", "add", "--no-cache", "squid=4.13-r0", "tini"]
+RUN ["apk", "add", "--no-cache", "squid=4.14-r0", "tini"]
 RUN echo '' > /etc/squid/squid.conf
 
 RUN mkdir /squid && chown -R user /squid && chown -R user /etc/squid/squid.conf


### PR DESCRIPTION
4.13 no longer available in Alpine main repo causing build to fail.

4.14 changes are minor: https://github.com/squid-cache/squid/commit/5f37a71acd0d24c3713316a06401a72e9f3194bc